### PR TITLE
Remove npm package axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "wagtail-supertable",
       "version": "0.1.0",
       "dependencies": {
-        "axios": "^0.21.2",
         "babel-preset-env": "^1.7.0",
         "classlist-polyfill": "^1.2.0",
         "classnames": "^2.2.5",
@@ -794,14 +793,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/babel-code-frame": {
@@ -2371,25 +2362,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/fraction.js": {
@@ -4810,14 +4782,6 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -6197,11 +6161,6 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
-    },
-    "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "fraction.js": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "start": "webpack watch --mode development --devtool eval-source-map"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.2",
     "@babel/core": "^7.21.0",
+    "autoprefixer": "^10.4.2",
     "babel-loader": "^8.2.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-polyfill": "^6.16.0",
@@ -36,7 +36,6 @@
     "webpack-merge": "^4.1.0"
   },
   "dependencies": {
-    "axios": "^0.21.2",
     "babel-preset-env": "^1.7.0",
     "classlist-polyfill": "^1.2.0",
     "classnames": "^2.2.5",


### PR DESCRIPTION
We are not using this package as far as I can tell.  It was affected by the vulnerability described here:

https://github.com/advisories/GHSA-wf5p-g6vw-rhxx

And it seemed easier to remove an unused package than to upgrade it.